### PR TITLE
Allow `flymake-bashate-max-line-length` to be nil in pre-check

### DIFF
--- a/flymake-bashate.el
+++ b/flymake-bashate.el
@@ -100,7 +100,8 @@ environment variable."
   :pre-check (progn
                (unless bashate-exec
                  (error "The '%s' executable was not found" bashate-exec))
-               (unless (numberp flymake-bashate-max-line-length)
+               (unless (or (null flymake-bashate-max-line-length)
+                           (numberp flymake-bashate-max-line-length))
                  (error
                   "The `flymake-bashate-max-line-length' must be a number")))
   :write-type 'file


### PR DESCRIPTION
This change updates the Flymake backend pre-check so `flymake-bashate-max-line-length`
accepts both `nil` and numeric values.

Previously, the backend rejected the default `nil` value even though `nil` is a valid
"no explicit limit" configuration and is already handled later in the code.

### What changed
- Relaxed the pre-check validation for `flymake-bashate-max-line-length`
- Allowed `nil` in addition to numeric values

### Why
This prevents the backend from failing in the default configuration.

Fixes #5 