### PR TITLE
Fix regex greediness in Flymake backend matching across newlines

### DIFF
--- a/flymake-bashate.el
+++ b/flymake-bashate.el
@@ -113,14 +113,14 @@ environment variable."
                      ,(number-to-string flymake-bashate-max-line-length)))
                ,fmqd-temp-file)
   :search-regexp (rx bol
-                     (zero-or-more anychar)
+                     (zero-or-more nonl)
                      (literal (file-name-nondirectory fmqd-temp-file)) ":"
                      (group (one-or-more digit)) ":"
                      (group (one-or-more digit)) ":"
                      (one-or-more (syntax whitespace))
                      (group "E" (one-or-more digit))
                      (one-or-more (syntax whitespace))
-                     (group (one-or-more anychar))
+                     (group (one-or-more nonl))
                      eol)
   :prep-diagnostic
   (let* ((lnum (string-to-number (match-string 1)))


### PR DESCRIPTION
This change updates the Flymake backend search regexp so diagnostics are matched
per line instead of greedily spanning across newlines.

Previously, the regexp used `anychar`, which could match newlines and caused
multiple Bashate warnings in the same file to be collapsed into a single diagnostic.

### What changed
- Replaced `anychar` with `nonl` in the `:search-regexp`
- Kept each diagnostic match bounded to a single line

### Why
This ensures multiple Bashate findings in one file are reported separately and
improves diagnostic accuracy in Flymake.

Fixes #6 